### PR TITLE
feat: Silverstripe 6 compatibility (4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Slideshow content block for SilverStripe Elemental
 
 ## Requirements
 
-* dnadesign/silverstripe-elemental: ^4.0
-* dynamic/flexslider: ^4.0
+* dnadesign/silverstripe-elemental: ^6
+* dynamic/flexslider: ^6
 
 ## Installation
 

--- a/_config.php
+++ b/_config.php
@@ -1,4 +1,3 @@
 <?php
 
-define('SILVERSTRIPE_ELEMENTAL-SLIDESHOW_PATH', __DIR__);
-define('SILVERSTRIPE_ELEMENTAL-SLIDESHOW_DIR', basename(__DIR__));
+// no-op

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,23 @@
             "homepage": "https://www.dynamicagency.com"
         }
     ],
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/dynamic"
+        }
+    ],
     "keywords": [
         "silverstripe", "elemental", "blocks", "dynamic", "flexslider", "slideshow"
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "dnadesign/silverstripe-elemental": "^4.8 || ^5",
-        "dynamic/flexslider": "^4.0 || ^5.0"
+        "dnadesign/silverstripe-elemental": "^6",
+        "dynamic/flexslider": "^6",
+        "silverstripe/vendor-plugin": "^3"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^2",
+        "silverstripe/recipe-testing": "^4",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "config": {
@@ -39,7 +46,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "4.x-dev"
         }
     },
     "scripts": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,16 @@
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
-    <testsuite name="silverstripe-elemental-flexslider">
-        <directory>tests</directory>
-    </testsuite>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="silverstripe-elemental-flexslider">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/src/ORM/ElementSlideshowSlideDataExtension.php
+++ b/src/ORM/ElementSlideshowSlideDataExtension.php
@@ -4,9 +4,9 @@ namespace Dynamic\Elements\Flexslider\ORM;
 
 use Dynamic\Elements\Flexslider\Elements\ElementSlideshow;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 
-class ElementSlideshowSlideDataExtension extends DataExtension
+class ElementSlideshowSlideDataExtension extends Extension
 {
     /**
      * @var array


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 4/5 support. Major version 4.0 requiring Silverstripe 6 only.
A `3` branch has been created from `master` for SS5 maintenance.

## Changes

- **composer.json**: `elemental ^6`, `flexslider ^6`, `vendor-plugin ^3`
- **require-dev**: `recipe-testing ^4`, `squizlabs/php_codesniffer ^3.0`
- **branch-alias**: `4.x-dev`
- **DataExtension → Extension**: Migrate `ElementSlideshowSlideDataExtension`
- **phpunit.xml.dist**: Update to PHPUnit 11 format
- **_config.php**: Remove deprecated `define()` constants
- **README.md**: Update requirements to SS6

## Version History

| Version | Silverstripe | Branch |
|---------|-------------|--------|
| 4.x     | ^6          | master |
| 3.x     | ^5          | 3      |
| 2.x     | ^4          | 2.1    |
